### PR TITLE
/api/teacher/subjects/{subjectId}で存在しないstudentIdsを渡したとき400エラーがでない問題

### DIFF
--- a/rest-client/teacher/api-teacher-subjects-{subjectId}.http
+++ b/rest-client/teacher/api-teacher-subjects-{subjectId}.http
@@ -111,7 +111,7 @@ Content-Type: application/json
 
 ###
 
-# @name 存在しないstudentIdsを渡したとき400エラー
+# @name 存在しないstudentIdsを渡したときuserIdは保存されない
 POST  {{baseUrl}}/api/teacher/subjects/1
 X-Auth-Token: {{token}}
 Content-Type: application/json


### PR DESCRIPTION
Fixes #146