### PR TITLE
api/teacher/students/{studentId}において、classIdが存在しない場合にBad RequestではなくNot Foundを返却する問題

### DIFF
--- a/src/main/java/sotsuken/api/teacher/service/ChangeStudentStatusUseCase.java
+++ b/src/main/java/sotsuken/api/teacher/service/ChangeStudentStatusUseCase.java
@@ -22,7 +22,7 @@ public class ChangeStudentStatusUseCase {
 
     public StudentStatusResponse handle(String userId, String studentId, String studentName, Long classId) {
         Student student = studentRepository.findById(studentId).orElseThrow(() -> new ErrorResponseException(HttpStatus.NOT_FOUND));
-        StudentClass studentclass = studentClassRepository.findById(classId).orElseThrow(() -> new ErrorResponseException(HttpStatus.NOT_FOUND));
+        StudentClass studentclass = studentClassRepository.findById(classId).orElseThrow(() -> new ErrorResponseException(HttpStatus.BAD_REQUEST));
         
         student.changeName(studentName);
         student.changeClass(studentclass);


### PR DESCRIPTION
Fixes #150