### PR TITLE
/api/student/registerにおいて、存在しないclassIdを指定した場合に403エラーが発生する問題

### DIFF
--- a/src/main/java/sotsuken/api/config/GlobalExceptionHandler.java
+++ b/src/main/java/sotsuken/api/config/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package sotsuken.api.config;
+
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.ErrorResponseException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    
+    @ExceptionHandler(value = ErrorResponseException.class)
+    public ProblemDetail handleAll(ErrorResponseException ex) {
+        return ex.getBody();
+    }
+}

--- a/src/main/java/sotsuken/api/config/SecurityConfig.java
+++ b/src/main/java/sotsuken/api/config/SecurityConfig.java
@@ -26,8 +26,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers("/api/auth/login").permitAll()
                         .requestMatchers("/api/auth/userinfo").authenticated()
-                        .requestMatchers("/api/student/**").hasRole("STUDENT")
                         .requestMatchers("/api/student/register", "/api/student/classes").permitAll()
+                        .requestMatchers("/api/student/**").hasRole("STUDENT")
                         .requestMatchers("/api/teachers/**").hasRole("TEACHER")
                         .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers("/swagger-ui/**").permitAll()


### PR DESCRIPTION
Fixes #141