### PR TITLE
/api/teacher/subjects/{subjectId}/lectures/{lectureId}において、subjectidの出力とlectureidの出力が逆

### DIFF
--- a/src/main/java/sotsuken/api/teacher/service/FetchLectureUseCase.java
+++ b/src/main/java/sotsuken/api/teacher/service/FetchLectureUseCase.java
@@ -19,7 +19,7 @@ public class FetchLectureUseCase {
     @Autowired
     SubjectRepository subjectRepository;
 
-    public SubjectLectureResponse handle(String userId, Long lectureId, Long subjectId) {
+    public SubjectLectureResponse handle(String userId, Long subjectId,Long lectureId) {
         Subject subject = subjectRepository.findById(subjectId)
             .orElseThrow(() -> new ErrorResponseException(HttpStatus.NOT_FOUND));
 


### PR DESCRIPTION
Fixes #142