### PR TITLE
api/teacher/subjects/{subjectId}/lecturesにおいて、subjectIdが存在しない場合にBad Requestが返却される問題

### DIFF
--- a/src/main/java/sotsuken/api/teacher/service/AddLectureUseCase.java
+++ b/src/main/java/sotsuken/api/teacher/service/AddLectureUseCase.java
@@ -48,7 +48,7 @@ public class AddLectureUseCase {
             Long periods) {
 
         Subject subject = subjectRepository.findById(subjectId)
-                .orElseThrow(() -> new ErrorResponseException(HttpStatus.BAD_REQUEST));
+                .orElseThrow(() -> new ErrorResponseException(HttpStatus.NOT_FOUND));
         Lecture newLecture = new Lecture(
                 null,
                 lectureName,


### PR DESCRIPTION
Fixes #155